### PR TITLE
Improved cache entry revalidation, 'bypassHeaders' function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = function(cache, defaults){
     var cachedEntry;
 
     // Special handling for the '304 Not Modified' case, which will only come out
-    // in case of the server responses with 'ETag' and 'Modification-Date'.
+    // in case of server responses with 'ETag' and/or 'Last-Modified' headers.
     Request.on('response', function (res) {
       if (res.status === 304 && cachedEntry) {
         res.status = cachedEntry.response.status;

--- a/utils.js
+++ b/utils.js
@@ -11,6 +11,7 @@ module.exports = {
     var cleanOptions = null;
     var params = this.getQueryParams(req);
     var options = this.getHeaderOptions(req);
+    props.pruneHeader = ['if-none-match', 'if-modified-since'].concat(props.pruneHeader || []);
     if(props.pruneQuery || props.pruneHeader){
       cleanParams = (props.pruneQuery) ? this.pruneObj(this.cloneObject(params), props.pruneQuery) : params;
       cleanOptions = (props.pruneHeader) ? this.pruneObj(this.cloneObject(options), props.pruneHeader, true) : options;
@@ -47,23 +48,23 @@ module.exports = {
    * Find and extract headers
    * @param {object} reg
    */
-  getHeaderOptions: function(_req){
+  getHeaderOptions: function(req){
     // I have to remove the User-Agent header ever since superagent 1.7.0
     // The cache-control header must also be removed.
     // Clone the request first, as we don't want to remove the headers from the original one, do we?
-    const req = JSON.parse(JSON.stringify(_req));
+    const _req = req ? JSON.parse(JSON.stringify(req)) : req;
     const headersToPrune = ['user-agent', 'cache-control'];
-    if(req && req.headers){
-      return this.pruneObj(req.headers, headersToPrune);
+    if(_req && _req.headers){
+      return this.pruneObj(_req.headers, headersToPrune);
     }
-    else if(req && req._header){
-      return this.pruneObj(req._header, headersToPrune);
+    else if(_req && _req._header){
+      return this.pruneObj(_req._header, headersToPrune);
     }
-    else if(req && req.req && req.req._headers){
-      return this.pruneObj(req.req._headers, headersToPrune);
+    else if(_req && _req.req && _req.req._headers){
+      return this.pruneObj(_req.req._headers, headersToPrune);
     }
-    else if(req && req.header){
-      return this.pruneObj(req.header, headersToPrune);
+    else if(_req && _req.header){
+      return this.pruneObj(_req.header, headersToPrune);
     }
     return null;
   },
@@ -132,13 +133,17 @@ module.exports = {
 
   /**
    * Simplify superagent's http response object
-   * @param {object} r
+   * @param {object} r - The response.
+   * @param {object} Request - The superagent's Request instance.
+   * @param {object} props  - The request properties.
    */
-  gutResponse: function(r){
+  gutResponse: function(r, Request, props){
     var newResponse = {};
+    newResponse.req = Request.toJSON();
     newResponse.body = r.body;
     newResponse.text = r.text;
-    newResponse.headers = r.headers;
+    newResponse.header = r.header;
+    newResponse.headers = r.header;
     newResponse.statusCode = r.statusCode;
     newResponse.status = r.status;
     newResponse.ok = r.ok;
@@ -182,7 +187,8 @@ module.exports = {
       expiration: d.expiration,
       forceUpdate: d.forceUpdate,
       preventDuplicateCalls: d.preventDuplicateCalls,
-      backgroundRefresh: d.backgroundRefresh
+      backgroundRefresh: d.backgroundRefresh,
+      bypassHeaders: d.bypassHeaders
     };
   },
 
@@ -192,8 +198,22 @@ module.exports = {
    * @param {object} err
    * @param {object} response
    * @param {string} key
+   * @param {object} [Request] - Superagent Request instance. When provided it will emit the events.
+   * @param {object} props  - The request internal properties.
    */
-  callbackExecutor: function(cb, err, response, key){
+  callbackExecutor: function(cb, err, response, key, Request){
+    if (response) {
+      // Superagent response should bear only the 'header' attribute, this was only needed for the policy.
+      delete response.headers;
+      if (Request) {
+        Request.emit('request', Request);
+        if (err) {
+          Request.emit('error', err);
+        } else {
+          Request.emit('response', response);
+        }
+      }
+    }
     if(cb.length === 1){
       cb(response);
     }
@@ -213,10 +233,17 @@ module.exports = {
    * @param {object} props  - The request-basis properties, which affect cache behavior.
    * @returns {object} The modified properties.
    */
-  handleReqCacheHeaders: function(req, props) {
+  handleReqCacheHeaders: function (req, props) {
     const cacheControl = req.get('cache-control');
-    if (typeof cacheControl === 'string' && cacheControl.toLowerCase().indexOf('only-if-cached') !== -1) {
-      props.doQuery = false;
+    if (typeof cacheControl === 'string') {
+      if (cacheControl.toLowerCase().indexOf('only-if-cached') !== -1) {
+        props.doQuery = false;
+      }
+      // the expiration can also be set via the Request header.
+      const maxAgeMatch = cacheControl.toLowerCase().match(/^(.*max-age=)(\d*).*$/);
+      if (maxAgeMatch) {
+        props.expiration = parseInt(maxAgeMatch[2]);
+      }
     }
     // We cheat the policy a bit here, giving the request instead of response (we don't have it at this stage),
     // as we want to parse the request headers for the caching control related values,
@@ -227,5 +254,65 @@ module.exports = {
     // The legacy method 'expiration()' will set the policy TTL value via the Cache-Control max-age value,
     // so no conflicts here.
     props.expiration = policy.storable() ? Math.round(policy.timeToLive() / 1000) : 0;
+  },
+
+  /**
+   * Returns the `expiration` (TTL) value calculated as a minimum of the `props.expiration` and `policy.timeToLive`.
+   * The resulting value is multiplied by `2`due to enable further handling of the stale cache entries,
+   * (when the policy allows for that).
+   * The resulting value is to be used for underlying cache implementation.
+   *
+   * @param {object} props  - The request-basis properties, which affect cache behavior.
+   * @param {object} policy - The cache policy.
+   * @returns {number} The expiration (TTL) time in seconds.
+   */
+  getExpiration: function (props, policy) {
+    return props.expiration
+      ? Math.min(props.expiration * 2, Math.round(policy.timeToLive() * 2 / 1000))
+      :  Math.round(policy.timeToLive() * 2 / 1000);
+  },
+
+  /**
+   * Sets the response header value.
+   *
+   * @param {object} response - The response instance.
+   * @param {string} name     - The header name.
+   * @param {string} value    - The header value.
+   * @returns {object} The incoming modified response.
+   */
+  setResponseHeader: function (response, name, value) {
+    // both need to be checked as someone could do strange things with 'prune' or 'responseProp'.
+    if (response) {
+      if (response.header) {
+        response.header[name] = value;
+      }
+      if (response.headers) {
+        response.headers[name] = value;
+      }
+    }
+    return response;
+  },
+
+  /**
+   * Copies the header values declared with the `bypassHeaders` option from current request
+   * to a cached response headers and its bound request headers.
+   *
+   * @param {object} response - The response instance.
+   * @param {object} req      - The request object.
+   * @param {object} props  - The request-basis properties, which affect cache behavior.
+   * @returns {object} The incoming modified response.
+   */
+  copyBypassHeaders: function (response, req, props) {
+    const self = this;
+    if (props.bypassHeaders && props.bypassHeaders.forEach) {
+      props.bypassHeaders.forEach(function (name) {
+        const value = req.get(name);
+        self.setResponseHeader(response, name, value);
+        if (response.req && response.req.headers) {
+          response.req.headers[name] = value;
+        }
+      });
+    }
+    return response;
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -241,7 +241,7 @@ module.exports = {
       }
       // the expiration can also be set via the Request header.
       const maxAgeMatch = cacheControl.toLowerCase().match(/^(.*max-age=)(\d*).*$/);
-      if (maxAgeMatch) {
+      if (maxAgeMatch && maxAgeMatch.length > 2 && maxAgeMatch[2] !== '') {
         props.expiration = parseInt(maxAgeMatch[2]);
       }
     }
@@ -267,9 +267,7 @@ module.exports = {
    * @returns {number} The expiration (TTL) time in seconds.
    */
   getExpiration: function (props, policy) {
-    return props.expiration
-      ? Math.min(props.expiration * 2, Math.round(policy.timeToLive() * 2 / 1000))
-      :  Math.round(policy.timeToLive() * 2 / 1000);
+    return Math.min(props.expiration * 2 || Number.MAX_VALUE, Math.round(policy.timeToLive() * 2 / 1000));
   },
 
   /**


### PR DESCRIPTION
Necessary changes for the `requestId` bypassing, between requests and cached responses.